### PR TITLE
Fix for Lines Beginning with Bolded Word

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -136,8 +136,8 @@ export function * headingLevels (tokens) {
   for (let token of tokens) {
     let headingLevel = 0
     if (token.type !== 'code') {
-      const [__, octos] = token.text.match(/^(\*+)?/)
-      if (octos) headingLevel = octos.length
+      const [__, octos] = token.text.match(/^(\*+ )?/)
+      if (octos) headingLevel = octos.length - 1
     }
     yield Object.assign(token, { headingLevel })
   }


### PR DESCRIPTION
Fix for folding line(s) when line begins with bolded word, e.g. `*Note:*`, instead of heading.

- Updated heading regular expression to match official org-mode heading syntax.
- Adjusted `headingLevel` to expected value